### PR TITLE
Refactor: Clean up IChatOrchestrator and fix ProcessWithOrchestrator flow

### DIFF
--- a/Assets/Scripts/Bootstrap/DependencyBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/DependencyBootstrap.cs
@@ -54,7 +54,6 @@ namespace ChatSystem.Bootstrap
             CreateServices();
             RegisterAgents();
             CreateControllers();
-            ConfigureServices();
             ConnectComponents();
             
             if (createDebugObjects)
@@ -70,12 +69,13 @@ namespace ChatSystem.Bootstrap
             contextManager = new ContextManager();
             persistenceService = new PersistenceService();
             agentExecutor = new AgentExecutor();
-            llmOrchestrator = new LLMOrchestrator(agentExecutor);
-            chatOrchestrator = new ChatOrchestrator(defaultConversationId);
             
             RegisterToolSets();
             
-            LoggingService.LogInfo("Core services created");
+            llmOrchestrator = new LLMOrchestrator(agentExecutor);
+            chatOrchestrator = new ChatOrchestrator(llmOrchestrator, contextManager, persistenceService);
+            
+            LoggingService.LogInfo("Core services created with dependency injection");
         }
         
         private void RegisterAgents()
@@ -108,21 +108,9 @@ namespace ChatSystem.Bootstrap
         private void CreateControllers()
         {
             chatController = new ChatController(defaultConversationId);
-            LoggingService.LogInfo("Controllers created");
-        }
-        
-        private void ConfigureServices()
-        {
             chatController.SetChatOrchestrator(chatOrchestrator);
             
-            if (chatOrchestrator is ChatOrchestrator chatOrchestratorImpl)
-            {
-                chatOrchestratorImpl.SetLLMOrchestrator(llmOrchestrator);
-                chatOrchestratorImpl.SetContextManager(contextManager);
-                chatOrchestratorImpl.SetPersistenceService(persistenceService);
-            }
-            
-            LoggingService.LogInfo("Services configured");
+            LoggingService.LogInfo("Controllers created and configured");
         }
         
         private void ConnectComponents()

--- a/Assets/Scripts/Services/Orchestrators/Interfaces/IChatOrchestrator.cs
+++ b/Assets/Scripts/Services/Orchestrators/Interfaces/IChatOrchestrator.cs
@@ -1,20 +1,11 @@
 using System.Threading.Tasks;
-using ChatSystem.Models.Context;
 using ChatSystem.Models.LLM;
-using ChatSystem.Services.Context.Interfaces;
-using ChatSystem.Services.Persistence.Interfaces;
 
 namespace ChatSystem.Services.Orchestrators.Interfaces
 {
     public interface IChatOrchestrator
     {
         Task<LLMResponse> ProcessUserMessageAsync(string conversationId, string userMessage);
-        Task<LLMResponse> ProcessMessageAsync(string conversationId, Message message);
-        void SetLLMOrchestrator(ILLMOrchestrator llmOrchestrator);
-        void SetContextManager(IContextManager contextManager);
-        void SetPersistenceService(IPersistenceService persistenceService);
-        Task<string> GetConversationContextAsync(string conversationId);
-        Task ClearConversationAsync(string conversationId);
         string GetConversationContext(string conversationId);
         void ClearConversation(string conversationId);
     }


### PR DESCRIPTION
## Changes Made

### 1. Simplified IChatOrchestrator Interface
- Removed unused methods: `ProcessMessageAsync`, `SetLLMOrchestrator`, `SetContextManager`, `SetPersistenceService`, `GetConversationContextAsync`, `ClearConversationAsync`
- Kept only essential methods: `ProcessUserMessageAsync`, `GetConversationContext`, `ClearConversation`

### 2. Refactored ChatOrchestrator
- Changed to constructor dependency injection instead of setter methods
- Eliminates the problematic cast requirement in DependencyBootstrap
- Added detailed logging to track response success/failure states

### 3. Updated DependencyBootstrap
- Now uses proper dependency injection pattern
- Removed the type casting hack: `if (chatOrchestrator is ChatOrchestrator chatOrchestratorImpl)`
- Cleaner service initialization order

### 4. Enhanced ChatController Logging
- Added detailed logs in `ProcessWithOrchestrator` to identify why it goes to else branch
- Logs response.success, content length, and error message details
- Will help debug the "Orchestrator error:" empty message issue

## Testing
Run the system and check logs to see:
- Which branch ProcessUserMessageAsync takes
- Response success/failure details
- Content and error message states

This should resolve the unused methods issue and provide debugging info for the empty error problem.